### PR TITLE
Fix the Makefile to make it conform to standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: elf iso disk disk-src run irun kirun info clean fullclean
+
 # build kernel
 elf:
 	python3 maketool.py elf_image

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,21 @@
 .PHONY: elf iso disk disk-src run irun kirun info clean fullclean
 
+elf: profanOS.elf
+
+iso: profanOS.iso
+
+disk: HDD.bin
+
 # build kernel
-elf:
+profanOS.elf:
 	python3 maketool.py elf_image
 
 # create iso with grub
-iso:
-	python3 maketool.py elf_image
+profanOS.iso: profanOS.elf
 	python3 maketool.py iso
 
 # build disk image with zapps
-disk:
+HDD.bin:
 	python3 maketool.py diskf
 
 disk-src:


### PR DESCRIPTION
In the `Makefile` I noticed that there were multiple targets that didn't directly refer to output files (ie all of them), since these don't refer to files, they need to be marked as `.PHONY` using this syntax:
```
.PHONY: <target names>
```
I then noticed there were multiple targets that resulted in a single file (`elf`, `iso` and `disk`), so I changed the target names in the `Makefile` to reference those files and added proxy `PHONY` targets to build them and ensure that the build process was still compatible. 