### PR TITLE
Add `-fno-stack-protector` to `CFLAGS`

### DIFF
--- a/maketool.py
+++ b/maketool.py
@@ -22,7 +22,7 @@ HDD_MAP = {
 CC = "gcc"
 CPPC = "g++"
 
-CFLAGS = "-m32 -g -ffreestanding -Wall -Wextra -fno-exceptions"
+CFLAGS = "-m32 -g -ffreestanding -Wall -Wextra -fno-exceptions -fno-stack-protector"
 KERN_FLAGS = f"{CFLAGS} -fno-pie -I include/kernel -I include/zlibs"
 ZAPP_FLAGS = f"{CFLAGS} -Wno-unused -I include/zlibs"
 


### PR DESCRIPTION
This fixes the linker error that reads:
```
undefined reference to `__stack_chk_fail'
```
I believe this is required since this is freestanding and doesn't link to `ssp`