### PR TITLE
Use `-march=i686` to fix invalid opcode errors

### DIFF
--- a/maketool.py
+++ b/maketool.py
@@ -23,7 +23,7 @@ HDD_MAP = {
 CC = "gcc"
 CPPC = "g++"
 
-CFLAGS = "-m32 -g -ffreestanding -Wall -Wextra -fno-exceptions -fno-stack-protector"
+CFLAGS = "-m32 -g -ffreestanding -Wall -Wextra -fno-exceptions -fno-stack-protector -march=i686"
 KERN_FLAGS = f"{CFLAGS} -fno-pie -I include/kernel -I include/zlibs"
 ZAPP_FLAGS = f"{CFLAGS} -Wno-unused -I include/zlibs"
 


### PR DESCRIPTION
Errors originated since GCC12 was using the `MOVDQA` instruction which is SSE2 only, and profanOS doesn't yet initialise those extensions.